### PR TITLE
Add rule for subjects starting with a capital letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This is a [Danger Plugin][danger] that ensures nice and tidy commit messages.
 
+[danger]: https://github.com/danger/danger
+
 ## Installation
 
 ```
@@ -61,13 +63,3 @@ commit_lint.check disable: :all
 ```
 
 This will actually throw a warning that Commit Lint isn't doing anything.
-
-## Development
-
-1. Clone this repo
-2. Run `bundle install` to setup dependencies.
-3. Run `bundle exec rake spec` to run the tests.
-4. Use `bundle exec guard` to automatically have tests run as you make changes.
-5. Make your changes.
-
-[danger]: https://github.com/danger/danger

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ commit_lint.check
 
 That will check each commit in the PR to ensure the following is true:
 
+* Commit subject begins with a capital letter (`subject_cap`)
 * Commit subject is no longer than 50 characters (`subject_length`)
 * Commit subject does not end in a period (`subject_period`)
 * Commit subject and body are separated by an empty line (`empty_line`)

--- a/lib/commit_lint/gem_version.rb
+++ b/lib/commit_lint/gem_version.rb
@@ -1,3 +1,3 @@
 module CommitLint
-  VERSION = '0.0.1'.freeze
+  VERSION = '0.0.2'.freeze
 end

--- a/lib/commit_lint/plugin.rb
+++ b/lib/commit_lint/plugin.rb
@@ -30,6 +30,7 @@ module Danger
     #
     #        The current check types are:
     #
+    #        * `subject_cap`
     #        * `subject_length`
     #        * `subject_period`
     #        * `empty_line`

--- a/lib/commit_lint/plugin.rb
+++ b/lib/commit_lint/plugin.rb
@@ -42,7 +42,7 @@ module Danger
       @config = config
 
       if all_checks_disabled?
-        warn NOOP_MESSAGE
+        messaging.warn NOOP_MESSAGE
       else
         check_messages
       end

--- a/lib/commit_lint/plugin.rb
+++ b/lib/commit_lint/plugin.rb
@@ -63,7 +63,7 @@ module Danger
     end
 
     def checkers
-      [SubjectLengthCheck, SubjectPeriodCheck, EmptyLineCheck]
+      [SubjectCapCheck, SubjectLengthCheck, SubjectPeriodCheck, EmptyLineCheck]
     end
 
     def checks

--- a/lib/commit_lint/subject_cap_check.rb
+++ b/lib/commit_lint/subject_cap_check.rb
@@ -1,0 +1,19 @@
+module Danger
+  class DangerCommitLint < Plugin
+    class SubjectCapCheck < CommitCheck # :nodoc:
+      MESSAGE = 'Please start subject with capital letter.'.freeze
+
+      def self.type
+        :subject_cap
+      end
+
+      def initialize(message)
+        @first_character = message[:subject].split('').first
+      end
+
+      def fail?
+        @first_character != @first_character.upcase
+      end
+    end
+  end
+end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,4 +1,5 @@
 require 'commit_lint/commit_check'
+require 'commit_lint/subject_cap_check'
 require 'commit_lint/subject_length_check'
 require 'commit_lint/subject_period_check'
 require 'commit_lint/empty_line_check'

--- a/spec/commit_lint_spec.rb
+++ b/spec/commit_lint_spec.rb
@@ -3,10 +3,11 @@ require File.expand_path('../spec_helper', __FILE__)
 # rubocop:disable Metrics/LineLength
 
 TEST_MESSAGES = {
+  subject_cap: 'this subject needs a capital',
   subject_length: 'This is a really long subject line and should result in an error',
   subject_period: 'This subject line ends in a period.',
   empty_line: "This subject line is fine\nBut then I forgot the empty line separating the subject and the body.",
-  all_errors: "This is a really long subject and it even ends in a period.\nNot to mention the missing empty line!",
+  all_errors: "this is a really long subject and it even ends in a period.\nNot to mention the missing empty line!",
   valid:  "This is a valid message\n\nYou can tell because it meets all the criteria and the linter does not complain."
 }.freeze
 
@@ -30,6 +31,7 @@ module Danger
       context 'with invalid messages' do
         it 'fails those checks' do
           checks = {
+            subject_cap: SubjectCapCheck::MESSAGE,
             subject_length: SubjectLengthCheck::MESSAGE,
             subject_period: SubjectPeriodCheck::MESSAGE,
             empty_line: EmptyLineCheck::MESSAGE
@@ -58,8 +60,9 @@ module Danger
           commit_lint.check
 
           status_report = commit_lint.status_report
-          expect(report_counts(status_report)).to eq 3
+          expect(report_counts(status_report)).to eq 4
           expect(status_report[:errors]).to eq [
+            SubjectCapCheck::MESSAGE,
             SubjectLengthCheck::MESSAGE,
             SubjectPeriodCheck::MESSAGE,
             EmptyLineCheck::MESSAGE
@@ -119,7 +122,9 @@ module Danger
           commit = double(:commit, message: TEST_MESSAGES[:all_errors])
           allow(commit_lint.git).to receive(:commits).and_return([commit])
 
-          all_checks = [:subject_length, :subject_period, :empty_line]
+          all_checks = [
+            :subject_cap, :subject_length, :subject_period, :empty_line
+          ]
           commit_lint.check disable: all_checks
 
           status_report = commit_lint.status_report
@@ -199,8 +204,9 @@ module Danger
             commit_lint.check warn: :all
 
             status_report = commit_lint.status_report
-            expect(report_counts(status_report)).to eq 3
+            expect(report_counts(status_report)).to eq 4
             expect(status_report[:warnings]).to eq [
+              SubjectCapCheck::MESSAGE,
               SubjectLengthCheck::MESSAGE,
               SubjectPeriodCheck::MESSAGE,
               EmptyLineCheck::MESSAGE
@@ -279,8 +285,9 @@ module Danger
             commit_lint.check fail: :all
 
             status_report = commit_lint.status_report
-            expect(report_counts(status_report)).to eq 3
+            expect(report_counts(status_report)).to eq 4
             expect(status_report[:errors]).to eq [
+              SubjectCapCheck::MESSAGE,
               SubjectLengthCheck::MESSAGE,
               SubjectPeriodCheck::MESSAGE,
               EmptyLineCheck::MESSAGE


### PR DESCRIPTION
I forgot an easy one: commit subject lines should start with a capital letter.
