### PR TITLE
Improve inline docs

### DIFF
--- a/lib/commit_lint/gem_version.rb
+++ b/lib/commit_lint/gem_version.rb
@@ -1,3 +1,3 @@
 module CommitLint
-  VERSION = '0.0.2'.freeze
+  VERSION = '0.0.3'.freeze
 end

--- a/lib/commit_lint/plugin.rb
+++ b/lib/commit_lint/plugin.rb
@@ -1,6 +1,16 @@
 module Danger
   # Run each commit in the PR through a message linting.
   #
+  #  Commit lint will check each commit in the PR to ensure the following is true:
+  #
+  #  * Commit subject begins with a capital letter (`subject_cap`)
+  #  * Commit subject is no longer than 50 characters (`subject_length`)
+  #  * Commit subject does not end in a period (`subject_period`)
+  #  * Commit subject and body are separated by an empty line (`empty_line`)
+  #
+  #  By default, Commit Lint fails, but you can configure this behavior.
+  #
+  #
   # @example Lint all commits using defaults
   #
   #          commit_lint.check
@@ -21,21 +31,22 @@ module Danger
 
     # Checks the commits with whatever config the user passes.
     #
+    # Passing in a hash which contain the following keys:
+    #
+    #  * `disable` - array of checks to skip
+    #  * `fail` - array of checks to fail on
+    #  * `warn` - array of checks to warn on
+    #
+    #  The current check types are:
+    #
+    #  * `subject_cap`
+    #  * `subject_length`
+    #  * `subject_period`
+    #  * `empty_line`
+    #
+    #  Note: you can pass :all instead of an array to target all checks.
+    #
     # @param [Hash] config
-    #        This hash can contain the following keys:
-    #
-    #        * `disable` - array of checks to skip
-    #        * `fail` - array of checks to fail on
-    #        * `warn` - array of checks to warn on
-    #
-    #        The current check types are:
-    #
-    #        * `subject_cap`
-    #        * `subject_length`
-    #        * `subject_period`
-    #        * `empty_line`
-    #
-    #        Note: you can pass :all instead of an array to target all checks.
     #
     # @return [void]
     #


### PR DESCRIPTION
[I linked to your plugin](https://twitter.com/orta/status/774253199276539904), then realized that all the docs were in the README, so I've moved a bunch of it inline which should raise it's profile on danger systems.

I've not really expected massive parameter docs, so they're cropped to one liners, consider this noted and if I see a few more, I'll be dealing with it properly.

Inline docs on Danger Systems will looks like when you release an update to the gem:

---
### commit_lint

Run each commit in the PR through a message linting.

 Commit lint will check each commit in the PR to ensure the following is true:
- Commit subject begins with a capital letter (`subject_cap`)
- Commit subject is no longer than 50 characters (`subject_length`)
- Commit subject does not end in a period (`subject_period`)
- Commit subject and body are separated by an empty line (`empty_line`)
  
  By default, Commit Lint fails, but you can configure this behavior.

<blockquote>Lint all commits using defaults
  <pre>
commit_lint.check</pre>
</blockquote>


<blockquote>Warn instead of fail
  <pre>
commit_lint.check warn: :all</pre>
</blockquote>


<blockquote>Disable a particular check
  <pre>
commit_lint.check disable: [:subject_period]</pre>
</blockquote>

#### Methods

`check` - Checks the commits with whatever config the user passes.

Passing in a hash which contain the following keys:
- `disable` - array of checks to skip
- `fail` - array of checks to fail on
- `warn` - array of checks to warn on
  
  The current check types are:
- `subject_cap`
- `subject_length`
- `subject_period`
- `empty_line`
  
  Note: you can pass :all instead of an array to target all checks.
