### PR TITLE
Switch out Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.1
+  - 2.3.3
+  - 2.4.0
   - jruby-9
 
 script:


### PR DESCRIPTION
I don't really understand why `2.2` works, but `2.3` and `2.4` do not. I
took a look here:

```
http://rubies.travis-ci.org/
```

And it's true that both `2.3` and `2.4` are not on that list, but
neither is `2.2`!

For #11