### PR TITLE
Express danger plugin dependency in terms of plugin api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.1
-  - jruby-9.1.9.0
+  - 2.4.5
+  - 2.5.5
+  - 2.6.2
+  - jruby-9.2.6.0
 
 script:
   - bundle exec rake

--- a/danger-commit_lint.gemspec
+++ b/danger-commit_lint.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'commit_lint/gem_version.rb'

--- a/danger-commit_lint.gemspec
+++ b/danger-commit_lint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'danger', '~> 5.0'
+  spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'

--- a/lib/commit_lint/plugin.rb
+++ b/lib/commit_lint/plugin.rb
@@ -113,6 +113,7 @@ module Danger
 
     def warning_checks
       return checks if @config[:warn] == :all
+
       @config[:warn] || []
     end
 

--- a/lib/commit_lint/subject_length_check.rb
+++ b/lib/commit_lint/subject_length_check.rb
@@ -2,8 +2,8 @@ module Danger
   class DangerCommitLint < Plugin
     class SubjectLengthCheck < CommitCheck # :nodoc:
       MESSAGE = 'Please limit commit subject line to 50 characters.'.freeze
-      GIT_GENERATED_SUBJECT = /^Merge branch \'.+\' into\ /
-      GITHUB_GENERATED_SUBJECT = /^Merge pull request #\d+ from\ /
+      GIT_GENERATED_SUBJECT = /^Merge branch \'.+\' into\ /.freeze
+      GITHUB_GENERATED_SUBJECT = /^Merge pull request #\d+ from\ /.freeze
 
       attr_reader :subject
 

--- a/spec/commit_lint_spec.rb
+++ b/spec/commit_lint_spec.rb
@@ -9,7 +9,7 @@ TEST_MESSAGES = {
   subject_period: 'This subject line ends in a period.',
   empty_line: "This subject line is fine\nBut then I forgot the empty line separating the subject and the body.",
   all_errors: "this is a really long subject and it even ends in a period.\nNot to mention the missing empty line!",
-  valid:  "This is a valid message\n\nYou can tell because it meets all the criteria and the linter does not complain."
+  valid: "This is a valid message\n\nYou can tell because it meets all the criteria and the linter does not complain."
 }.freeze
 
 # rubocop:enable Metrics/LineLength

--- a/spec/subject_length_check_spec.rb
+++ b/spec/subject_length_check_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../spec_helper', __FILE__)
+require File.expand_path('spec_helper', __dir__)
 
 describe Danger::DangerCommitLint::SubjectLengthCheck do
   describe '#fail?' do


### PR DESCRIPTION
Looks like it's safer to express this dependency in terms of the plugin api, rather than the danger gem version. Thanks @jk for the tip!

/cc @orta does this sound right to you?

Closes #23 