### PR TITLE
Add limit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ By default, Commit Lint fails, but you can configure this behavior.
 
 ## Configuration
 
-Configuring Commit Lint is done by passing a hash. The three keys that can be
+Configuring Commit Lint is done by passing a hash. The four keys that can be
 passed are:
 
 * `disable`
 * `fail`
 * `warn`
+* `limit`
 
-To each of these keys you can pass either the symbol `:all` or an array of
+The first three of these keys can accept either the symbol `:all` or an array of
 checks. Here are some ways you could configure Commit Lint:
 
 ```ruby
@@ -69,3 +70,16 @@ commit_lint.check disable: :all
 ```
 
 This will actually throw a warning that Commit Lint isn't doing anything.
+
+
+### Limiting number of commits checked
+
+The `limit` key allows you to limit checks to the first `n` commits. This can be
+useful for PR workflows when squashing before merge where you want the initial
+commit message to be linted, but want to exclude additional commits pushed in
+response to change requests during a code review.
+
+```ruby
+# limit checks to only the first commit
+commit_lint.check limit: 1
+```

--- a/lib/commit_lint/plugin.rb
+++ b/lib/commit_lint/plugin.rb
@@ -38,6 +38,7 @@ module Danger
     #  * `disable` - array of checks to skip
     #  * `fail` - array of checks to fail on
     #  * `warn` - array of checks to warn on
+    #  * `limit` - limits checks to first N commits
     #
     #  The current check types are:
     #
@@ -121,7 +122,17 @@ module Danger
       @config[:warn] || []
     end
 
+    def commit_limit
+      @config[:limit] || 0
+    end
+
     def messages
+      return parsed_messages if commit_limit.zero?
+
+      parsed_messages.first(commit_limit)
+    end
+
+    def parsed_messages
       git.commits.map do |commit|
         (subject, empty_line) = commit.message.split("\n")
         {


### PR DESCRIPTION
Adds the ability to limit the checks to the first `n` commits. Useful
for PR workflows where you want the initial commit message to be
linted, but want to exclude additional commits pushed in response
to change requests during a code review since these will be squashed
and rolled up into the first commit message during merge.