### PR TITLE
Fix limit filtering order

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,14 @@ commit_lint.check disable: :all
 
 This will actually throw a warning that Commit Lint isn't doing anything.
 
-
 ### Limiting number of commits checked
 
-The `limit` key allows you to limit checks to the first `n` commits. This can be
-useful for PR workflows when squashing before merge where you want the initial
-commit message to be linted, but want to exclude additional commits pushed in
-response to change requests during a code review.
+The `limit` key allows you to limit checks to the first `n` commits (oldest to
+newest). This can be useful for PR workflows when squashing before merge where
+you want the initial commit message to be linted, but want to exclude additional
+commits pushed in response to change requests during a code review.
 
 ```ruby
-# limit checks to only the first commit
+# limit checks to only the first (oldest) commit
 commit_lint.check limit: 1
 ```

--- a/lib/commit_lint/plugin.rb
+++ b/lib/commit_lint/plugin.rb
@@ -129,7 +129,7 @@ module Danger
     def messages
       return parsed_messages if commit_limit.zero?
 
-      parsed_messages.first(commit_limit)
+      parsed_messages.last(commit_limit)
     end
 
     def parsed_messages

--- a/spec/commit_lint_spec.rb
+++ b/spec/commit_lint_spec.rb
@@ -322,7 +322,7 @@ module Danger
       let(:commit3) { double(:commit, message: message, sha: sha) }
 
       def message_with_sha(message)
-        [message, sha1, sha2].join "\n"
+        [message, sha2, sha3].join "\n"
       end
 
       it 'fails checks only on messages within limit' do


### PR DESCRIPTION
Fixes the filtering for the `limit` configuration option so it starts
with the oldest commits in the change set.